### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/src/utils/set.js
+++ b/src/utils/set.js
@@ -42,11 +42,18 @@ const error = require('./error')
 const getObjKeyPair = require('./getObjKeyPair')
 const CoreObject = require('../core/CoreObject')
 
+function disallowProtoPath (attr, key) {
+  if (attr === Object.prototype) {
+    throw new Error('Unsafe path encountered: ' + key)
+  }
+}
+
 function set (obj, key, val, quiet, skipCompare) {
   let meta
   if (typeof key === 'string') {
     if (key.indexOf('.') > -1) {
       obj = getObjKeyPair(obj, key, true)
+      disallowProtoPath(obj[0], key)
       key = obj[1]
       obj = obj[0]
     }


### PR DESCRIPTION
### 📊 Metadata *

`Prototype Pollution` in `decal`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-decal/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


1. Create the following PoC file:

// poc.js
```
var decal = require("decal")
var obj = {}
console.log("Before : " + {}.polluted);
decal.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

2. Execute the following commands in terminal:

```
npm i decal # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107071312-87aaa000-680a-11eb-9227-4892637d0d2e.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107072945-b32e8a00-680c-11eb-8f9b-bf0553748bb7.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/107072176-c725bc00-680b-11eb-95c6-3659d6440700.png)
![image](https://user-images.githubusercontent.com/64132745/107072304-f4726a00-680b-11eb-80d4-a0421c333136.png)
![image](https://user-images.githubusercontent.com/64132745/107072337-fd633b80-680b-11eb-85bf-78db50180ae9.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1848
